### PR TITLE
AEAA-294 added includeAdvisoryTypes parameter

### DIFF
--- a/documents/reports/example-report/pom.xml
+++ b/documents/reports/example-report/pom.xml
@@ -116,6 +116,8 @@
                         <failOnMissingSources>false</failOnMissingSources>
 
                         <generateOverviewTablesForAdvisories>CERT-SEI</generateOverviewTablesForAdvisories>
+                        <!-- [alert, notice, news, all, none] -->
+                        <includeAdvisoryTypes>all</includeAdvisoryTypes>
                     </configuration>
 
                 </plugin>


### PR DESCRIPTION
> ⚠️ &nbsp;this PR should only be merged if the according PR in Core has been merged: https://github.com/org-metaeffekt/metaeffekt-core/pull/61

Added a `includeAdvisoryTypes` parameter to the vulnerability report:

```xml
<!-- [alert, notice, news, all, none] -->
<includeAdvisoryTypes>all</includeAdvisoryTypes>
```

Only advisories with a type listed in the comma-separated list will be included in the final report.

The default value for this parameter is `all`, meaning all advisories are included.
