### PR TITLE
update container-extractors pom to use overhauled container-extractors

### DIFF
--- a/extractors/container-extractors/pom.xml
+++ b/extractors/container-extractors/pom.xml
@@ -44,7 +44,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.6.0</version>
                     <executions>
                         <execution>
                             <id>unpack-container-scripts</id>
@@ -57,11 +57,17 @@
                                 <artifactItems>
                                     <artifactItem>
                                         <groupId>org.metaeffekt.core</groupId>
-                                        <artifactId>ae-inventory-maven-plugin</artifactId>
+                                        <artifactId>ae-system-analysis-scripts</artifactId>
                                         <version>${ae.core.version}</version>
+                                        <includes>ae-system-analysis-scripts-assembled/container-extractors/*.sh</includes>
+                                        <fileMappers>
+                                            <org.codehaus.plexus.components.io.filemappers.FlattenFileMapper/>
+                                            <org.codehaus.plexus.components.io.filemappers.PrefixFileMapper>
+                                                <prefix>container-extractors/</prefix>
+                                            </org.codehaus.plexus.components.io.filemappers.PrefixFileMapper>
+                                        </fileMappers>
                                     </artifactItem>
                                 </artifactItems>
-                                <includes>container-extractors/*.sh</includes>
                                 <overWriteSnapshots>true</overWriteSnapshots>
                             </configuration>
                         </execution>


### PR DESCRIPTION
Updates the "container-extractors" pom to deal with the new scripts artifact.

The maven-dependency plugin has been updated to version 3.6.0. Its configuration has been updated to support the new artifact. It matches the previous extraction behaviour.