### PR TITLE
AEAA-357: Add an example CVSS 4.0 vector

### DIFF
--- a/advisors/example-advisor/assessment/CVE-2021-44228.yaml
+++ b/advisors/example-advisor/assessment/CVE-2021-44228.yaml
@@ -17,6 +17,10 @@ affects:
 # (almost) every CVE has a CVSS score that can be further modified to account for environmental or temporal factors.
 # this can be done by providing a CVSS modification vector. Create a vector using the web interface:
 # cvss 2: https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?vector=(AV:L/AC:H/Au:M/C:N/I:N/A:N)
-# cvss 3: https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?vector=AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N
+# cvss 3: https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?name=CVE-2021-44228&vector=AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
 cvssV2: E:ND/RL:ND/RC:ND/CDP:MH/TD:M/CR:H/IR:H/AR:H
 cvssV3: E:H/RL:U/CR:M/IR:M/AR:M/MAC:H
+
+# fully custom cvss vector overwriting source vector:
+# cvss 4: https://www.first.org/cvss/calculator/4.0#CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H/MAC:H/MVC:L/CR:M/IR:M/AR:M
+cvssV4: CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H/MAC:H/MVC:L/CR:M/IR:M/AR:M


### PR DESCRIPTION
Since the implementation of CVSS 4.0 has been completed recently, the vectors can now be specified in the status files.

This PR adds an example CVSS 4.0 vector to the status file of CVE-2021-44228.

This PR requires a PR on AE-AA to be merged and it being released.