### PR TITLE
"advise" profile split into "advise-correlate" and "advise-vulnerability"

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,17 @@ Mirror the vulnerability databases once using the `mirror-database` profile:
 This may take around 10 minutes. The process will create a local mirror of public vulnerability data in the `.database`
 folder. Rerun the process to update the data regularly.
 
-Run the extraction and advisories/documents generation using the `extract,advise,document` profiles:
+Run the extraction and advisories/documents generation using the `extract`, `advise`, `document` profiles:
 
     mvn clean install -Pextract,advise,document,report
+
+The profile `advise` is split into two separate profiles `advise-correlate` and `advise-vulnerability`, which are
+activated by default. To disable one of these, use `-P-advice-correlate` or `-P-advice-vulnerability`. This allows for
+splitting the advise process into two separate steps, see [advisors/pom.xml (~line 148)](advisors/pom.xml) in addition
+to the commands below for more details:
+
+    mvn clean install -Padvise,-advise-vulnerability
+    mvn       install -Padvise,-advise-correlate,document,report
 
 The profiles extract, advise, document and report have been split using profiles to be used separately from the command
 line.

--- a/advisors/pom.xml
+++ b/advisors/pom.xml
@@ -30,6 +30,7 @@
         <output.inventory.intermediate.dir>${project.build.directory}/classes/inventory-intermediate/</output.inventory.intermediate.dir>
         <output.inventory.name>${project.artifactId}-inventory.xls</output.inventory.name>
         <output.inventory>${output.inventory.dir}/${output.inventory.name}</output.inventory>
+        <output.inventory.correlation>${output.inventory.dir}/correlation-${output.inventory.name}</output.inventory.correlation>
         <output.dashboard>${project.build.directory}/classes/dashboard/${project.artifactId}-dashboard.html</output.dashboard>
         <output.svg>${project.build.directory}/classes/resources/svg</output.svg>
 
@@ -138,175 +139,233 @@
                     </executions>
                 </plugin>
 
-                <plugin>
-                    <groupId>com.metaeffekt.artifact.analysis</groupId>
-                    <artifactId>ae-inventory-enrichment-plugin</artifactId>
-                    <version>${ae.artifact.analysis.version}</version>
-
-                    <executions>
-                        <execution>
-                            <id>inventory-enrichment-execution</id>
-                            <goals>
-                                <goal>enrich-inventory</goal>
-                            </goals>
-
-                            <configuration>
-                                <inventoryInputFile>${input.inventory}</inventoryInputFile>
-                                <inventoryOutputFile>${output.inventory}</inventoryOutputFile>
-                                <mirrorDirectory>${input.database}</mirrorDirectory>
-
-                                <writeIntermediateInventories>true</writeIntermediateInventories>
-                                <storeIntermediateStepsInInventoryInfo>true</storeIntermediateStepsInInventoryInfo>
-                                <intermediateInventoriesDirectory>${output.inventory.intermediate.dir}</intermediateInventoriesDirectory>
-
-                                <!--<resumeAtEnrichment>resume-at</resumeAtEnrichment>-->
-                                <!--<enrichmentOrder></enrichmentOrder>-->
-
-                                <correlationYamlEnrichment>
-                                    <active>${activate.correlation}</active>
-                                    <yamlFiles>
-                                        <file>${correlation.dir}</file>
-                                    </yamlFiles>
-                                </correlationYamlEnrichment>
-
-                                <cpeDerivationEnrichment>
-                                    <active>${activate.nvd}</active>
-                                    <maxCorrelatedCpePerArtifact>2147483647</maxCorrelatedCpePerArtifact>
-                                </cpeDerivationEnrichment>
-
-                                <msVulnerabilitiesByProductEnrichment>
-                                    <active>${activate.msrc}</active>
-                                </msVulnerabilitiesByProductEnrichment>
-
-                                <nvdMatchCveFromCpeEnrichment>
-                                    <active>${activate.nvd}</active>
-                                    <maxCorrelatedVulnerabilitiesPerArtifact>2147483647</maxCorrelatedVulnerabilitiesPerArtifact>
-                                </nvdMatchCveFromCpeEnrichment>
-
-                                <customVulnerabilitiesFromCpeEnrichment>
-                                    <active>${activate.vulnerabilities.custom}</active>
-                                    <vulnerabilityFiles>
-                                        <file>${vulnerabilities.custom.dir}</file>
-                                    </vulnerabilityFiles>
-                                </customVulnerabilitiesFromCpeEnrichment>
-
-                                <ghsaVulnerabilitiesEnrichment>
-                                    <active>${activate.ghsa}</active>
-                                    <maven>true</maven>
-                                    <packagist>false</packagist>
-                                    <rubygems>true</rubygems>
-                                    <githubactions>false</githubactions>
-                                    <pypi>true</pypi>
-                                    <purl_type_swift>false</purl_type_swift>
-                                    <go>false</go>
-                                    <hex>true</hex>
-                                    <npm>true</npm>
-                                    <crates_io>true</crates_io>
-                                    <pub>false</pub>
-                                    <nuget>true</nuget>
-                                    <githubReviewed>false</githubReviewed>
-                                </ghsaVulnerabilitiesEnrichment>
-
-                                <nvdCveFillDetailsEnrichment>
-                                    <active>${activate.nvd}</active>
-                                    <cvssSeverityRanges>${cvssSeverityRanges}</cvssSeverityRanges>
-                                </nvdCveFillDetailsEnrichment>
-
-                                <customVulnerabilitiesFillDetailsEnrichment>
-                                    <active>${activate.vulnerabilities.custom}</active>
-                                    <vulnerabilityFiles>
-                                        <file>${vulnerabilities.custom.dir}</file>
-                                    </vulnerabilityFiles>
-                                    <cvssSeverityRanges>${cvssSeverityRanges}</cvssSeverityRanges>
-                                </customVulnerabilitiesFillDetailsEnrichment>
-
-                                <msrcAdvisorFillDetailsEnrichment>
-                                    <active>${activate.msrc}</active>
-                                    <cvssSeverityRanges>${cvssSeverityRanges}</cvssSeverityRanges>
-                                </msrcAdvisorFillDetailsEnrichment>
-
-                                <!--
-                                <ghsaAdvisorFillDetailsEnrichment>
-                                    <active>${activate.ghsa}</active>
-                                    <cvssSeverityRanges>${cvssSeverityRanges}</cvssSeverityRanges>
-                                </ghsaAdvisorFillDetailsEnrichment>
--->
-
-                                <vulnerabilityStatusEnrichment>
-                                    <active>${activate.status}</active>
-                                    <statusFiles>
-                                        <file>${assessment.dir}</file>
-                                    </statusFiles>
-                                    <cvssSeverityRanges>${cvssSeverityRanges}</cvssSeverityRanges>
-                                    <activeLabels>${assessment.labels}</activeLabels>
-                                </vulnerabilityStatusEnrichment>
-
-                                <vulnerabilityKeywordsEnrichment>
-                                    <active>${activate.keywords}</active>
-                                    <yamlFiles>
-                                        <file>${keywords.dir}</file>
-                                    </yamlFiles>
-                                    <cvssSeverityRanges>${cvssSeverityRanges}</cvssSeverityRanges>
-                                    <activeLabels>${keywords.labels}</activeLabels>
-                                </vulnerabilityKeywordsEnrichment>
-
-                                <certFrAdvisorEnrichment>
-                                    <active>${activate.certfr}</active>
-                                    <cvssSeverityRanges>${cvssSeverityRanges}</cvssSeverityRanges>
-                                </certFrAdvisorEnrichment>
-
-                                <certSeiAdvisorEnrichment>
-                                    <active>${activate.certsei}</active>
-                                    <cvssSeverityRanges>${cvssSeverityRanges}</cvssSeverityRanges>
-                                </certSeiAdvisorEnrichment>
-
-
-                                <inventoryValidationEnrichment>
-                                    <active>${activate.validation}</active>
-                                    <failOnValidationErrors>false</failOnValidationErrors>
-                                    <addAsCorrelationWarnings>true</addAsCorrelationWarnings>
-
-                                    <additionalCpeIsNotEffectiveInventoryValidator/>
-                                    <multipleArtifactsAndVersionsOnVulnerabilityInventoryValidator>
-                                        <versionLevel>minor</versionLevel>
-                                    </multipleArtifactsAndVersionsOnVulnerabilityInventoryValidator>
-                                    <!--artifactAndCpeVersionsDifferGreatlyInventoryValidator/ -->
-                                    <vulnerabilityInvalidNameValidator/>
-                                </inventoryValidationEnrichment>
-
-                                <vulnerabilityFilterEnrichment>
-                                    <active>false</active>
-                                    <vulnerabilityIncludeFilter></vulnerabilityIncludeFilter>
-                                </vulnerabilityFilterEnrichment>
-
-                                <vulnerabilityAssessmentDashboardEnrichment>
-                                    <active>${activate.dashboard}</active>
-                                    <outputDashboardFile>${output.dashboard}</outputDashboardFile>
-                                    <svgDirectory>${output.svg}</svgDirectory>
-
-                                    <!-- deprecated: Use vulnerabilityIncludeFilter instead -->
-                                    <minimumVulnerabilityIncludeScore>-2147483648</minimumVulnerabilityIncludeScore>
-                                    <vulnerabilityIncludeFilter></vulnerabilityIncludeFilter>
-                                    <maximumVulnerabilitiesPerDashboardCount>2147483647</maximumVulnerabilitiesPerDashboardCount>
-                                    <insignificantThreshold>${ae.dashboard.insignificant.threshold}</insignificantThreshold>
-
-                                    <vulnerabilityTimelinesGlobalEnabled>${ae.dashboard.timeline}</vulnerabilityTimelinesGlobalEnabled>
-                                    <maximumCpeForTimelinesPerVulnerability>2147483647</maximumCpeForTimelinesPerVulnerability>
-                                    <maximumVulnerabilitiesPerTimeline>${ae.dashboard.cve.limit}</maximumVulnerabilitiesPerTimeline>
-                                    <vulnerabilityTimelineHideIrrelevantVersions>true</vulnerabilityTimelineHideIrrelevantVersions>
-                                    <maximumVersionsPerTimeline>2147483647</maximumVersionsPerTimeline>
-                                    <maximumTimeSpentOnTimelines>2147483647</maximumTimeSpentOnTimelines>
-
-                                    <failOnVulnerabilityWithoutSpecifiedRisk>true</failOnVulnerabilityWithoutSpecifiedRisk>
-                                    <failOnUnreviewedAdvisories>true</failOnUnreviewedAdvisories>
-                                    <failOnUnreviewedAdvisoriesTypes></failOnUnreviewedAdvisoriesTypes>
-                                    <cvssSeverityRanges>${cvssSeverityRanges}</cvssSeverityRanges>
-                                </vulnerabilityAssessmentDashboardEnrichment>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <profile>
+            <id>advise-correlate</id>
+            <activation> <!-- activate by default, unless disabled via -P-advise-correlate -->
+                <property>
+                    <name>maven.version</name>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>com.metaeffekt.artifact.analysis</groupId>
+                            <artifactId>ae-inventory-enrichment-plugin</artifactId>
+                            <version>${ae.artifact.analysis.version}</version>
+
+                            <executions>
+                                <execution>
+                                    <id>inventory-enrichment-advise-correlate-execution</id>
+                                    <phase>generate-resources</phase>
+                                    <goals>
+                                        <goal>enrich-inventory</goal>
+                                    </goals>
+
+                                    <configuration>
+                                        <inventoryInputFile>${input.inventory}</inventoryInputFile>
+                                        <inventoryOutputFile>${output.inventory.correlation}</inventoryOutputFile>
+                                        <mirrorDirectory>${input.database}</mirrorDirectory>
+
+                                        <writeIntermediateInventories>true</writeIntermediateInventories>
+                                        <storeIntermediateStepsInInventoryInfo>true</storeIntermediateStepsInInventoryInfo>
+                                        <intermediateInventoriesDirectory>${output.inventory.intermediate.dir}</intermediateInventoriesDirectory>
+
+                                        <!--<resumeAtEnrichment>resume-at</resumeAtEnrichment>-->
+                                        <!--<enrichmentOrder></enrichmentOrder>-->
+
+                                        <correlationYamlEnrichment>
+                                            <active>${activate.correlation}</active>
+                                            <yamlFiles>
+                                                <file>${correlation.dir}</file>
+                                            </yamlFiles>
+                                        </correlationYamlEnrichment>
+
+                                        <cpeDerivationEnrichment>
+                                            <active>${activate.nvd}</active>
+                                            <maxCorrelatedCpePerArtifact>2147483647</maxCorrelatedCpePerArtifact>
+                                        </cpeDerivationEnrichment>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <id>advise-vulnerability</id>
+            <activation> <!-- activate by default, unless disabled via -P-advise-vulnerability -->
+                <property>
+                    <name>maven.version</name>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>com.metaeffekt.artifact.analysis</groupId>
+                            <artifactId>ae-inventory-enrichment-plugin</artifactId>
+                            <version>${ae.artifact.analysis.version}</version>
+
+                            <executions>
+                                <execution>
+                                    <id>inventory-enrichment-advise-vulnerability-execution</id>
+                                    <phase>compile</phase>
+                                    <goals>
+                                        <goal>enrich-inventory</goal>
+                                    </goals>
+
+                                    <configuration>
+                                        <inventoryInputFile>${output.inventory.correlation}</inventoryInputFile>
+                                        <inventoryOutputFile>${output.inventory}</inventoryOutputFile>
+                                        <mirrorDirectory>${input.database}</mirrorDirectory>
+
+                                        <writeIntermediateInventories>true</writeIntermediateInventories>
+                                        <storeIntermediateStepsInInventoryInfo>true</storeIntermediateStepsInInventoryInfo>
+                                        <intermediateInventoriesDirectory>${output.inventory.intermediate.dir}</intermediateInventoriesDirectory>
+
+                                        <!--<resumeAtEnrichment>resume-at</resumeAtEnrichment>-->
+                                        <!--<enrichmentOrder></enrichmentOrder>-->
+
+                                        <msVulnerabilitiesByProductEnrichment>
+                                            <active>${activate.msrc}</active>
+                                        </msVulnerabilitiesByProductEnrichment>
+
+                                        <nvdMatchCveFromCpeEnrichment>
+                                            <active>${activate.nvd}</active>
+                                            <maxCorrelatedVulnerabilitiesPerArtifact>2147483647</maxCorrelatedVulnerabilitiesPerArtifact>
+                                        </nvdMatchCveFromCpeEnrichment>
+
+                                        <customVulnerabilitiesFromCpeEnrichment>
+                                            <active>${activate.vulnerabilities.custom}</active>
+                                            <vulnerabilityFiles>
+                                                <file>${vulnerabilities.custom.dir}</file>
+                                            </vulnerabilityFiles>
+                                        </customVulnerabilitiesFromCpeEnrichment>
+
+                                        <ghsaVulnerabilitiesEnrichment>
+                                            <active>${activate.ghsa}</active>
+                                            <maven>true</maven>
+                                            <packagist>false</packagist>
+                                            <rubygems>true</rubygems>
+                                            <githubactions>false</githubactions>
+                                            <pypi>true</pypi>
+                                            <purl_type_swift>false</purl_type_swift>
+                                            <go>false</go>
+                                            <hex>true</hex>
+                                            <npm>true</npm>
+                                            <crates_io>true</crates_io>
+                                            <pub>false</pub>
+                                            <nuget>true</nuget>
+                                            <githubReviewed>false</githubReviewed>
+                                        </ghsaVulnerabilitiesEnrichment>
+
+                                        <nvdCveFillDetailsEnrichment>
+                                            <active>${activate.nvd}</active>
+                                            <cvssSeverityRanges>${cvssSeverityRanges}</cvssSeverityRanges>
+                                        </nvdCveFillDetailsEnrichment>
+
+                                        <customVulnerabilitiesFillDetailsEnrichment>
+                                            <active>${activate.vulnerabilities.custom}</active>
+                                            <vulnerabilityFiles>
+                                                <file>${vulnerabilities.custom.dir}</file>
+                                            </vulnerabilityFiles>
+                                            <cvssSeverityRanges>${cvssSeverityRanges}</cvssSeverityRanges>
+                                        </customVulnerabilitiesFillDetailsEnrichment>
+
+                                        <msrcAdvisorFillDetailsEnrichment>
+                                            <active>${activate.msrc}</active>
+                                            <cvssSeverityRanges>${cvssSeverityRanges}</cvssSeverityRanges>
+                                        </msrcAdvisorFillDetailsEnrichment>
+
+                                        <!--<ghsaAdvisorFillDetailsEnrichment>
+                                            <active>${activate.ghsa}</active>
+                                            <cvssSeverityRanges>${cvssSeverityRanges}</cvssSeverityRanges>
+                                        </ghsaAdvisorFillDetailsEnrichment>-->
+
+                                        <vulnerabilityStatusEnrichment>
+                                            <active>${activate.status}</active>
+                                            <statusFiles>
+                                                <file>${assessment.dir}</file>
+                                            </statusFiles>
+                                            <cvssSeverityRanges>${cvssSeverityRanges}</cvssSeverityRanges>
+                                            <activeLabels>${assessment.labels}</activeLabels>
+                                        </vulnerabilityStatusEnrichment>
+
+                                        <vulnerabilityKeywordsEnrichment>
+                                            <active>${activate.keywords}</active>
+                                            <yamlFiles>
+                                                <file>${keywords.dir}</file>
+                                            </yamlFiles>
+                                            <cvssSeverityRanges>${cvssSeverityRanges}</cvssSeverityRanges>
+                                            <activeLabels>${keywords.labels}</activeLabels>
+                                        </vulnerabilityKeywordsEnrichment>
+
+                                        <certFrAdvisorEnrichment>
+                                            <active>${activate.certfr}</active>
+                                            <cvssSeverityRanges>${cvssSeverityRanges}</cvssSeverityRanges>
+                                        </certFrAdvisorEnrichment>
+
+                                        <certSeiAdvisorEnrichment>
+                                            <active>${activate.certsei}</active>
+                                            <cvssSeverityRanges>${cvssSeverityRanges}</cvssSeverityRanges>
+                                        </certSeiAdvisorEnrichment>
+
+
+                                        <inventoryValidationEnrichment>
+                                            <active>${activate.validation}</active>
+                                            <failOnValidationErrors>false</failOnValidationErrors>
+                                            <addAsCorrelationWarnings>true</addAsCorrelationWarnings>
+
+                                            <additionalCpeIsNotEffectiveInventoryValidator/>
+                                            <multipleArtifactsAndVersionsOnVulnerabilityInventoryValidator>
+                                                <versionLevel>minor</versionLevel>
+                                            </multipleArtifactsAndVersionsOnVulnerabilityInventoryValidator>
+                                            <!--artifactAndCpeVersionsDifferGreatlyInventoryValidator/ -->
+                                            <vulnerabilityInvalidNameValidator/>
+                                        </inventoryValidationEnrichment>
+
+                                        <vulnerabilityFilterEnrichment>
+                                            <active>false</active>
+                                            <vulnerabilityIncludeFilter></vulnerabilityIncludeFilter>
+                                        </vulnerabilityFilterEnrichment>
+
+                                        <vulnerabilityAssessmentDashboardEnrichment>
+                                            <active>${activate.dashboard}</active>
+                                            <outputDashboardFile>${output.dashboard}</outputDashboardFile>
+                                            <svgDirectory>${output.svg}</svgDirectory>
+
+                                            <!-- deprecated: Use vulnerabilityIncludeFilter instead -->
+                                            <minimumVulnerabilityIncludeScore>-2147483648</minimumVulnerabilityIncludeScore>
+                                            <vulnerabilityIncludeFilter></vulnerabilityIncludeFilter>
+                                            <maximumVulnerabilitiesPerDashboardCount>2147483647</maximumVulnerabilitiesPerDashboardCount>
+                                            <insignificantThreshold>${ae.dashboard.insignificant.threshold}</insignificantThreshold>
+
+                                            <vulnerabilityTimelinesGlobalEnabled>${ae.dashboard.timeline}</vulnerabilityTimelinesGlobalEnabled>
+                                            <maximumCpeForTimelinesPerVulnerability>2147483647</maximumCpeForTimelinesPerVulnerability>
+                                            <maximumVulnerabilitiesPerTimeline>${ae.dashboard.cve.limit}</maximumVulnerabilitiesPerTimeline>
+                                            <vulnerabilityTimelineHideIrrelevantVersions>true</vulnerabilityTimelineHideIrrelevantVersions>
+                                            <maximumVersionsPerTimeline>2147483647</maximumVersionsPerTimeline>
+                                            <maximumTimeSpentOnTimelines>2147483647</maximumTimeSpentOnTimelines>
+
+                                            <failOnVulnerabilityWithoutSpecifiedRisk>true</failOnVulnerabilityWithoutSpecifiedRisk>
+                                            <failOnUnreviewedAdvisories>true</failOnUnreviewedAdvisories>
+                                            <failOnUnreviewedAdvisoriesTypes></failOnUnreviewedAdvisoriesTypes>
+                                            <cvssSeverityRanges>${cvssSeverityRanges}</cvssSeverityRanges>
+                                        </vulnerabilityAssessmentDashboardEnrichment>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
The profile `advise` is split into two separate profiles `advise-correlate` and `advise-vulnerability`, which are
activated by default. To disable one of these, use `-P-advice-correlate` or `-P-advice-vulnerability`. This allows for
splitting the advise process into two separate steps, see [advisors/pom.xml (~line 148)](https://github.com/org-metaeffekt/metaeffekt-documentation-template/pull/12/files#diff-a891639b48a7d92ca79e8f3b5ca42a7e1c8b58489c30457ff46997b50dd3fff3R148) in addition
to the commands below for more details:

    mvn clean install -Padvise,-advise-vulnerability
    mvn       install -Padvise,-advise-correlate,document,report