### PR TITLE
AEAA-474: Added configurations for CERT-EU Mirror and enrichment

### DIFF
--- a/advisors/pom.xml
+++ b/advisors/pom.xml
@@ -54,6 +54,7 @@
         <activate.msrc>false</activate.msrc>
         <activate.nvd>true</activate.nvd>
         <activate.certfr>false</activate.certfr>
+        <activate.certeu>true</activate.certeu>
         <activate.certsei>true</activate.certsei>
         <activate.ghsa>true</activate.ghsa>
         <activate.correlation>true</activate.correlation>
@@ -302,6 +303,10 @@
                                         <certFrAdvisorEnrichment>
                                             <active>${activate.certfr}</active>
                                         </certFrAdvisorEnrichment>
+
+                                        <certEuAdvisorEnrichment>
+                                            <active>${activate.certeu}</active>
+                                        </certEuAdvisorEnrichment>
 
                                         <certSeiAdvisorEnrichment>
                                             <active>${activate.certsei}</active>

--- a/mirror/pom.xml
+++ b/mirror/pom.xml
@@ -78,6 +78,19 @@
                                         </resourceLocations>
                                     </certFrDownload>
 
+                                    <certEuDownload>
+                                        <resourceLocations>
+                                            <!-- HTML page containing a list of all CERT-EU entries published in a single year.
+                                                 - %d Year (example: 2020) -->
+                                            <YEARLY_PUBLICATIONS_URL>https://cert.europa.eu/publications/security-advisories/%d</YEARLY_PUBLICATIONS_URL>
+                                            <!-- JSON file containing the details of a single CERT-EU entry.
+                                                 - %s Entry ID (example: 2024-042) -->
+                                            <SINGLE_ENTRY_URL>https://cert.europa.eu/publications/security-advisories/%s/json</SINGLE_ENTRY_URL>
+                                            <!-- RSS feed for the latest updated/ created CERT-EU entries. Used to check if update is required. -->
+                                            <RSS_FEED>https://cert.europa.eu/publications/security-advisories-rss</RSS_FEED>
+                                        </resourceLocations>
+                                    </certEuDownload>
+
                                     <nvdCveDownload>
                                         <!-- you will need an API key in order to download the NVD data:
                                              https://nvd.nist.gov/developers/request-an-api-key
@@ -208,6 +221,7 @@
                                     <!-- Indexers -->
                                     <certSeiAdvisorIndex/>
                                     <certFrAdvisorIndex/>
+                                    <certEuAdvisorIndex/>
                                     <nvdVulnerabilityIndex/>
                                     <nvdCpeIndex/>
                                     <nvdCpeVendorProductIndex/>


### PR DESCRIPTION
> Note that IntelliJ, for whatever reason, replaced the commit message with one that refers to an older commit from a few weeks back. The proper commit message would be the issue title above.

Added support for CERT-EU.

```xml
<certEuAdvisorEnrichment>
    <active>${activate.certeu}</active>
</certEuAdvisorEnrichment>

<certEuDownload>
<certEuAdvisorIndex>
```

For this, these PRs need merging:

- https://github.com/org-metaeffekt/metaeffekt-core/pull/102
- https://github.com/org-metaeffekt/metaeffekt-artifact-analysis/pull/9
