### PR TITLE
added huawei to csaf blacklist

### DIFF
--- a/mirror/pom.xml
+++ b/mirror/pom.xml
@@ -194,10 +194,12 @@
                                         </listerList>-->
 
                                         <!-- filter providers fetched using the listers -->
-                                        <!--<excludeList>
-                                            <name></name>
-                                            <url></url>
-                                        </excludeList>-->
+                                        <excludeList>
+                                            <excluder>
+                                                <name>huawei_psirt</name>
+                                                <url>https://www.huawei.com/.well-known/csaf/provider-metadata.json</url>
+                                            </excluder>
+                                        </excludeList>
                                         <!--<includeList></includeList>-->
                                     </csafDownload>
 


### PR DESCRIPTION
huawei had to be disabled due to the csaf documents being locked behind being logged in to their [services](https://securitybulletin.huawei.com/.well-known/csaf/security-advisory/carrier/SG933068824152547328/en/)