### PR TITLE
AE-1160 Missing-csp

### DIFF
--- a/extractors/dependency-extractors/pom.xml
+++ b/extractors/dependency-extractors/pom.xml
@@ -120,8 +120,7 @@
                                 <targetInventoryPath>${project.artifactId}-inventory.xls</targetInventoryPath>
 
                                 <securityPolicy>
-                                    <file>${project.basedir}/../../../security-policy-configuration.json</file>
-                                    <activeIds>base</activeIds>
+                                    <failOnMissingPolicyFile>false</failOnMissingPolicyFile>
                                 </securityPolicy>
                             </configuration>
                         </execution>

--- a/extractors/dependency-extractors/pom.xml
+++ b/extractors/dependency-extractors/pom.xml
@@ -118,6 +118,11 @@
 
                                 <targetInventoryDir>${project.build.directory}/classes/inventory</targetInventoryDir>
                                 <targetInventoryPath>${project.artifactId}-inventory.xls</targetInventoryPath>
+
+                                <securityPolicy>
+                                    <file>${project.basedir}/../../../security-policy-configuration.json</file>
+                                    <activeIds>base</activeIds>
+                                </securityPolicy>
                             </configuration>
                         </execution>
                     </executions>


### PR DESCRIPTION
Configured 'create-scan-report' execution of 'ae-dependency-extractors' to not require CSP.

I don't see why this execution might require a cyber security policy at all; if this is the case, consider wrapping the mojo call to a new one which doesn’t require a statement about the necessity of a csp. 

[jira](https://metaeffekt.atlassian.net/jira/software/projects/AE/boards/11?selectedIssue=AE-1160)